### PR TITLE
Fix mqtt-sn binding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ VOLUME ["/mqtt/config"]
 COPY config/rsmb.conf /mqtt/config/
 
 EXPOSE 1883
-EXPOSE 1884/udp
 EXPOSE 1885/udp
 
 CMD ["broker_mqtts", "/mqtt/config/rsmb.conf"]

--- a/config/rsmb.conf
+++ b/config/rsmb.conf
@@ -5,7 +5,7 @@ trace_output protocol
 listener 1883 INADDR_ANY	
 		
 # MQTT-S listener
-listener 1884 INADDR_ANY mqtts					
+listener 1885 INADDR_ANY mqtts
 	# optional multicast groups to listen on
 	multicast_groups 224.0.18.83	
 	# optional advertise packets parameters: address, interval, gateway_id			


### PR DESCRIPTION
The docker-rsmb image provided appear to be miss configured. This PR change the listener port to 1885 as Ian Craggs suggest in http://modelbasedtesting.co.uk/?p=44  to fix exactly the same error:

```
20150624 094503.749 6 127.0.0.1:1885 01fd22e59738.mqtts -> MQTT-S CONNECT cleansession: 0 (0)
20150624 094503.749 CWNAN0075W Socket error 111 (Connection refused) in UDP read error for socket 6
20150624 094503.749 CWNAN0018W Socket error for client identifier 01fd22e59738.mqtts, socket 6, peer address 127.0.0.1:1885; ending connection
```

After this PR the proble was fixed:

```
20150624 102510.960 4 127.0.0.1:54616 16557ee6b8b1.mqtts -> MQTT-S PINGRESP (0)
20150624 102541.995 4  225.0.18.83:1883 -> MQTT-S ADVERTISE gateway_id: 33 duration: 30 (0)
20150624 102610.025 6 127.0.0.1:1885 16557ee6b8b1.mqtts -> MQTT-S PINGREQ (0)
20150624 102610.026 4 127.0.0.1:54616 16557ee6b8b1.mqtts -> MQTT-S PINGRESP (0)
20150624 102612.029 4  225.0.18.83:1883 -> MQTT-S ADVERTISE gateway_id: 33 duration: 30 (0)
20150624 102643.064 4  225.0.18.83:1883 -> MQTT-S ADVERTISE gateway_id: 33 duration: 30 (0)
```
